### PR TITLE
Add PEP-518 support for numpy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel", "numpy", "cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
To enable installation of pdqhash when numpy is not already installed, we can add a pyproject.toml file to specify that numpy and cython are requirements of the build system for pdqhash.

Tested locally running the following command:

```
❯ docker run -v `pwd`:/opt/pdqhash-python -it python:3.6 pip install /opt/pdqhash-python
Processing /opt/pdqhash-python
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Building wheels for collected packages: pdqhash
  Building wheel for pdqhash (PEP 517) ... done
  Created wheel for pdqhash: filename=pdqhash-0.2.1-cp36-cp36m-linux_x86_64.whl size=221833 sha256=4e8e524fb2b8bccdcea19eed102311d349d7602b3b47e864fefe7e6c2fa3020f
  Stored in directory: /root/.cache/pip/wheels/7e/cb/8d/f82e5bf3cfec0d42a9434c6bd01e2b3f2889080419dd1add82
Successfully built pdqhash
Installing collected packages: pdqhash
Successfully installed pdqhash-0.2.1
```

Additionally, the CI job should no longer have the output line on Step 6 ("Make Host Environment") saying:

```
An error occurred while installing numpy! Will try again.
```

Fixes #3.

