### PR TITLE
Exclude tests dir from package build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,10 @@ setup_requires =
     cython
     numpy
 
+[options.packages.find]
+exclude = tests
+
+
 [tool:pytest]
 filterwarnings =
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning


### PR DESCRIPTION
During the package installation process, it has been observed that the tests folder is relocated to `lib/../site-packages`. This relocation has led to disruptions in certain imports, such as:

```
from tests import something
```

Did you consider excluding it from the build?